### PR TITLE
Export type definitions to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
 	"version": "0.1.26",
 	"description": "convert table or spreadsheet data into an image",
 	"main": "./lib/index.js",
+	"types": "index.d.ts",
 	"files": [
-		"/lib"
+		"/lib",
+		"index.d.ts"
 	],
 	"scripts": {
 		"clean": "rimraf lib",


### PR DESCRIPTION
Thanks to #2 this handy package has a type definitions so that typescript user can write their code easily.
However, it does not export to the npm which makes it useless.

I have updated `package.json` to output `index.d.ts` file and marked as a type definition file.